### PR TITLE
Add GLIB_COMPILE_SCHEMAS environment variable

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -109,6 +109,9 @@ class LibnameConan(ConanFile):
             if self.options['fftw'].precision != "single":
                 raise ConanInvalidConfiguration("pulseaudio needs fftw to be built with option fftw:precision=single")
 
+        # TODO: Should be removed once/if https://github.com/conan-io/conan/issues/7720 is resolved
+        os.environ["GLIB_COMPILE_SCHEMAS"] = os.path.join(self.deps_cpp_info["glib"].rootpath, "bin", "glib-compile-schemas")
+
         autotools = self._configure_autotools()
         autotools.make()
 


### PR DESCRIPTION
This would be unnecessary if glib recipe defined `glib_compile_schemas` pkg_conf variable:
https://github.com/conan-io/conan/issues/7720

In `pulseaudio`'s configure:
```
if test -n "$GLIB_COMPILE_SCHEMAS"; then
    pkg_cv_GLIB_COMPILE_SCHEMAS="$GLIB_COMPILE_SCHEMAS"
else ...
pkg_cv_GLIB_COMPILE_SCHEMAS=`$PKG_CONFIG --variable="glib_compile_schemas" "gio-2.0" 2>/dev/null`
```